### PR TITLE
Makefile: Added `install` and `uninstall` targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,15 @@ remove:
 list:
 	sudo lsmod | grep $(MODULE_NAME)
 
+# Making `sudo modprobe MODULE_NAME` possible. Even when not in this directory
+install:
+	sudo install --mode=644 $(MODULE_NAME).ko /lib/modules/$(KVERSION)/
+	sudo depmod --all  # update "database"
+
+uninstall:
+	sudo rm -f /lib/module/$(KVERSION)/$(MODULE_NAME).ko
+	sudo depmod --all  # also update "database"
+
 format:
 	clang-format -i $(MODULE_NAME).c
 


### PR DESCRIPTION
For making `sudo modprobe gpio-mocking` possible.