### PR TITLE
README.md: sudo dmesg

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo insmod gpio-mockup.ko
 ```
 4. Verify the module is loaded by checking `dmesg`:
 ```shell
-dmesg | grep "Mockup GPIO"
+sudo dmesg | grep "Mockup GPIO"
 ```
 5. Confirm that the mock GPIO chip is registered using `gpiodetect`:
 ```shell


### PR DESCRIPTION
$ dmesg | grep "Mockup GPIO"
dmesg: read kernel buffer failed: Operation not permitted
$ sudo dmesg | grep "Mockup GPIO"
[ 1870.011839] gpio_mockup: Mockup GPIO chip registered
[ 1870.011864] gpio_mockup: Mockup GPIO module loaded
$